### PR TITLE
Add const assertion to `useCheckSigner`

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -32,7 +32,7 @@ function App() {
   
   useEffect(() => {
     if (signer.isConnected === true) {
-      setIsConnected(true); // if Typescript is naughty with you, you can write this: (setIsConnected as Dispatch<SetStateAction<boolean>>)(true);
+      setIsConnected(true);
     }
   }, [signer])
     

--- a/packages/hooks/docs.md
+++ b/packages/hooks/docs.md
@@ -71,7 +71,7 @@ const App = () => {
     // for your UI to react accordingly to the changes!
     useEffect(() => {
         if (signer.isConnected === true) {
-            setIsConnected(true); // if Typescript is naughty with you, you can write this: (setIsConnected as Dispatch<SetStateAction<boolean>>)(true);
+            setIsConnected(true);
         }
     }, [signer])
     
@@ -111,7 +111,7 @@ const App = () => {
     // for your UI to react accordingly to the changes!
     useEffect(() => {
         if (signer.isConnected === true) {
-            setIsConnected(true); // if Typescript is naughty with you, you can write this: (setIsConnected as Dispatch<SetStateAction<boolean>>)(true);
+            setIsConnected(true);
         }
     }, [signer])
     

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -111,7 +111,7 @@ const useCheckSigner = (clientName: string) => {
     })();
   }, [])
 
-  return [isConnected, setIsConnected];
+  return [isConnected, setIsConnected] as const;
 }
 
 const useEncryptedSigner = (clientName: string, token: Token) => {


### PR DESCRIPTION
This fix is already in place for the other hooks - it forces the tuple return type to be `[boolean, Dispatch<SetStateAction<boolean>>]` rather than `(boolean | Dispatch<SetStateAction<boolean>>)[]`.